### PR TITLE
meson: Fix warning in run_command usage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('ampart', 'c',
-    version : run_command('bash', 'scripts/build-only-version.sh').stdout().strip())
+    version : run_command('bash', 'scripts/build-only-version.sh', check: true).stdout().strip())
 incdir = include_directories('include')
 zlibdep = dependency('zlib')
 


### PR DESCRIPTION
Meson warns:

WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in meson 2.0.
         See also: https://github.com/mesonbuild/meson/issues/9300