### PR TITLE
github: update actions to v4

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Static build for x86_64
       run: make fresh STATIC=1
     - name: Rename for x86_64
@@ -37,7 +37,7 @@ jobs:
     # - name: Rename for aarch64
     #   run: mv ampart ampart-aarch64
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4.6.1
       with:
         name: static-build
         path: ampart-*


### PR DESCRIPTION
The GitHub Actions build currently fails with the following message:

  Error: This request has been automatically failed because it uses a
  deprecated version of `actions/upload-artifact: v3.1.2`. Learn more:
  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Update both actions/checkout and actions/upload-artifact to version 4.