### PR TITLE
meson: install ampart executable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,4 +7,5 @@ executable('ampart',
     'src/cli.c', 'src/dtb.c', 'src/dts.c', 'src/ept.c', 'src/gzip.c', 'src/io.c', 'src/main.c', 'src/parg.c', 'src/size.c', 'src/stringblock.c', 'src/util.c', 'src/version.c',
     dependencies : zlibdep,
     include_directories: incdir,
-    c_args: '-DVERSION="@0@"'.format(meson.project_version()))
+    c_args: '-DVERSION="@0@"'.format(meson.project_version()),
+    install: true)


### PR DESCRIPTION
Executables are only installed if the 'install' parameter is explicitly set to true.

https://mesonbuild.com/Reference-manual_functions.html#executable_install